### PR TITLE
address params:default error

### DIFF
--- a/granchild.lua
+++ b/granchild.lua
@@ -163,8 +163,11 @@ local function setup_params()
   params:add_option("delayscene","scene",{"a","b"},1)
   params:set_action("delayscene",function(scene)
     for _,param_name in ipairs(param_list_delay) do
-      params:hide(i..param_name..(3-scene))
-      params:show(i..param_name..scene)
+      params:hide(param_name..(3-scene))
+      params:show(param_name..scene)
+      if _menu.rebuild_params~=nil then
+        _menu.rebuild_params()
+      end
       local p=params:lookup_param(i..param_name..scene)
       p:bang()
     end


### PR DESCRIPTION
hihi @schollz ! hope all's well :)

from https://llllllll.co/t/error-init/56372, i noticed that when `params:default()` (or more specifically `params:bang()` is called on granchild _or_ when `PARAMETERS > delay > scene` was changed, the script reported this error:

```lua
/home/we/dust/code/granchild/granchild.lua:166: attempt to concatenate a nil value (global 'i')
stack traceback:
        /home/we/norns/lua/core/norns.lua:146: in metamethod '__concat'
        /home/we/dust/code/granchild/granchild.lua:166: in field 'action'
        /home/we/norns/lua/core/params/option.lua:52: in function 'core/params/option.bang'
        /home/we/norns/lua/core/paramset.lua:510: in function 'core/paramset.bang'
        /home/we/norns/lua/core/paramset.lua:503: in function 'core/paramset.default'
        /home/we/dust/code/arcify_dev/lib/mod.lua:108: in upvalue 'script_init'
        /home/we/dust/code/gridkeys/lib/mod.lua:579: in global 'init'
        /home/we/norns/lua/core/script.lua:126: in function 'core/script.init'
        [C]: in function 'xpcall'
        /home/we/norns/lua/core/norns.lua:147: in field 'try'
        /home/we/norns/lua/core/engine.lua:91: in function </home/we/norns/lua/core/engine.lua:89>
```

just looked like maybe the delay params used to be under the [`for i=1,num_voices do`](https://github.com/schollz/granchild/blob/main/granchild.lua#L41) umbrella? either way, removing the `i` invocation cleared up errors + allowed switching the delay scenes in the params. i also popped in a `_menu.rebuild_params()` (with your `nil` check) to get the change showing in the UI.

hopefully this helps? lmk!